### PR TITLE
Update heroku/buildpacks-dotnet to v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+
+- The buildpack will now retry SDK downloads up to 5 times. ([#17](https://github.com/heroku/heroku-buildpack-dotnet/pull/17))
 
 ## [v1] - 2024-11-30
 

--- a/bin/compile
+++ b/bin/compile
@@ -7,7 +7,7 @@ set -euo pipefail
 BUILD_DIR="${1}"
 ENV_DIR="${3}"
 
-DOTNET_CNB_VERSION="0.1.7"
+DOTNET_CNB_VERSION="0.1.8"
 
 BUILDPACK_DIR=$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)
 


### PR DESCRIPTION
https://github.com/heroku/buildpacks-dotnet/releases/tag/v0.1.8