### PR TITLE
Add CNB update workflow

### DIFF
--- a/.github/workflows/cnb.yml
+++ b/.github/workflows/cnb.yml
@@ -30,6 +30,8 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
+          # We always want the version bump and resultant PR to target main, not the branch of the workflow_dispatch.
+          ref: main
           token: ${{ steps.generate-token.outputs.token }}
 
       - name: Get next release and update files

--- a/.github/workflows/cnb.yml
+++ b/.github/workflows/cnb.yml
@@ -1,0 +1,99 @@
+name: CNB
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '00 4 * * 1-5'
+
+defaults:
+  run:
+    # Setting an explicit bash shell ensures GitHub Actions enables pipefail mode too,
+    # rather than only error on exit (improving failure UX when pipes are used). See:
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    shell: bash
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-cnb:
+    name: Update .NET CNB version
+    runs-on: pub-hk-ubuntu-24.04-ip
+
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: generate-token
+        with:
+          app-id: ${{ vars.LINGUIST_GH_APP_ID }}
+          private-key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
+
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Get next release and update files
+        id: get_next_release
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          # Get the currently pinned version
+          previous_version=$(awk -F'"' '/DOTNET_CNB_VERSION=/ {print $2}' bin/compile)
+
+          # Get all releases sorted by creation date
+          releases=$(gh release list --repo heroku/buildpacks-dotnet --limit 100 --json tagName --jq '.[].tagName' | tac)
+          next_release=""
+
+          # Find the next release after the pinned version
+          found_previous=false
+          for release in $releases; do
+            if [ "$found_previous" = "true" ]; then
+              next_release=${release#v}
+              break
+            fi
+            if [ "$release" = "v$previous_version" ]; then
+              found_previous=true
+            fi
+          done
+
+          # Handle cases where no next release is found
+          if [ -z "$next_release" ]; then
+            echo "No newer release found. Exiting."
+            exit 0
+          fi
+
+          echo "next_release=$next_release" >> $GITHUB_ENV
+
+          # Fetch release notes
+          RELEASE_NOTES=$(gh release view "v$next_release" --repo heroku/buildpacks-dotnet --json body --jq .body)
+          SAFE_NOTES=$(echo "$RELEASE_NOTES" | awk '/^### / {p=1} p {print}' | sed '/^## /,$d')
+
+          # Update bin/compile
+          sed -i "s/DOTNET_CNB_VERSION=\".*\"/DOTNET_CNB_VERSION=\"$next_release\"/" bin/compile
+
+          # Update CHANGELOG.md
+          if ! grep -q "## \[Unreleased\]" CHANGELOG.md; then
+            echo -e "## [Unreleased]\n\n$(cat CHANGELOG.md)" > CHANGELOG.md
+          fi
+          awk -v notes="$SAFE_NOTES" '/^## \[Unreleased\]/ {print; print ""; print notes; next} 1' CHANGELOG.md > temp && mv temp CHANGELOG.md
+
+      - name: Create Pull Request
+        id: create_pr
+        uses: peter-evans/create-pull-request@v7.0.5
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          title: "Update heroku/buildpacks-dotnet to v${{ env.next_release }}"
+          commit-message: "Update DOTNET_CNB_VERSION version to ${{ env.next_release }}"
+          committer: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>
+          author: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>
+          branch: update-dotnet-cnb-${{ env.next_release }}
+          body: |
+            This PR updates the pinned `DOTNET_CNB_VERSION` to [${{ env.next_release }}](https://github.com/heroku/buildpacks-dotnet/releases/tag/v${{ env.next_release }}).
+
+      - name: Configure PR
+        if: steps.create_pr.outputs.pull-request-operation == 'created'
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: gh pr merge --squash --auto "${{ steps.create_pr.outputs.pull-request-number }}"

--- a/.github/workflows/cnb.yml
+++ b/.github/workflows/cnb.yml
@@ -89,7 +89,7 @@ jobs:
           commit-message: "Update DOTNET_CNB_VERSION version to ${{ env.next_release }}"
           committer: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>
           author: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>
-          branch: update-dotnet-cnb-${{ env.next_release }}
+          branch: update-dotnet-cnb
           body: |
             This PR updates the pinned `DOTNET_CNB_VERSION` to [${{ env.next_release }}](https://github.com/heroku/buildpacks-dotnet/releases/tag/v${{ env.next_release }}).
 

--- a/.github/workflows/cnb.yml
+++ b/.github/workflows/cnb.yml
@@ -84,6 +84,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7.0.5
         with:
           token: ${{ steps.generate-token.outputs.token }}
+          reviewers: runesoerensen
           title: "Update heroku/buildpacks-dotnet to v${{ env.next_release }}"
           commit-message: "Update DOTNET_CNB_VERSION version to ${{ env.next_release }}"
           committer: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>

--- a/.github/workflows/cnb.yml
+++ b/.github/workflows/cnb.yml
@@ -12,10 +12,8 @@ defaults:
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
     shell: bash
 
-permissions:
-  actions: write
-  contents: write
-  pull-requests: write
+# Disable all GITHUB_TOKEN permissions, since the GitHub App token is used instead.
+permissions: {}
 
 jobs:
   update-cnb:


### PR DESCRIPTION
This workflow automates the process of keeping the `DOTNET_CNB_VERSION` in `bin/compile` and the `CHANGELOG.md` file up-to-date with new releases in the `heroku/buildpacks-dotnet` repository:

1. Extracts the currently pinned `DOTNET_CNB_VERSION` from `bin/compile`.
2. Queries the `heroku/buildpacks-dotnet` repository to find the next release following the currently pinned version.
3. Updates files in this repository:
   - Updates `bin/compile` to use the next CNB release.
   - Inserts the relevant release notes from the `heroku/buildpacks-dotnet` repository under the `## [Unreleased]` section of `CHANGELOG.md`.
4. Creates a PR titled `Update heroku/buildpacks-dotnet to v{next-cnb-release-version}` with a link to the corresponding release.

The workflow is executed on a schedule, but can also be triggered manually to allow multiple CNB version updates prior to executing the "Prepare Release" workflow.

Testing this type of workflow is a bit tricky, but should work fine for common/regular version updates. There are several areas we may want to improve in the future, such as automatically triggering this workflow following successful execution of https://github.com/heroku/buildpacks-dotnet/blob/main/.github/workflows/release.yml.

Maintainers may need to edit `CHANGELOG.md` manually (particularly to remove entries that are not relevant for this buildpack, e.g. changes to caching logic etc).