### PR TITLE
Redirect CNB stderr to stdout

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -127,7 +127,7 @@ format_cnb_output() {
 
 # Run CNB bin/build with formatted output
 run_build() {
-	"${CNB_BUILDPACK_DIR}/bin/build" "${CNB_BUILD_DIR}/layers" "${CNB_BUILD_DIR}/platform" "${CNB_BUILD_DIR}/buildpack_plan.toml" 2>&1 | format_cnb_output
+	"${CNB_BUILDPACK_DIR}/bin/build" "${CNB_BUILD_DIR}/layers" "${CNB_BUILD_DIR}/platform" "${CNB_BUILD_DIR}/buildpack_plan.toml" |& format_cnb_output
 }
 
 # Remove build layers to reduce slug size

--- a/bin/compile
+++ b/bin/compile
@@ -127,7 +127,7 @@ format_cnb_output() {
 
 # Run CNB bin/build with formatted output
 run_build() {
-	"${CNB_BUILDPACK_DIR}/bin/build" "${CNB_BUILD_DIR}/layers" "${CNB_BUILD_DIR}/platform" "${CNB_BUILD_DIR}/buildpack_plan.toml" | format_cnb_output
+	"${CNB_BUILDPACK_DIR}/bin/build" "${CNB_BUILD_DIR}/layers" "${CNB_BUILD_DIR}/platform" "${CNB_BUILD_DIR}/buildpack_plan.toml" 2>&1 | format_cnb_output
 }
 
 # Remove build layers to reduce slug size


### PR DESCRIPTION
The CNB was updated in [0.1.10](https://github.com/heroku/buildpacks-dotnet/releases/tag/v0.1.10) to properly write error output to stderr. The `format_cnb_output` function handles both types of output, so for now we redirect stderr so error output will continue to be properly formatted when the pinned CNB version is updated.