### PR TITLE
Verify .NET runtime dependencies

### DIFF
--- a/spec/fixtures/basic_web_8.0/bin/test-runtime.sh
+++ b/spec/fixtures/basic_web_8.0/bin/test-runtime.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Check that all dynamically linked libraries exist in the run image
+INSTALL_DIR="$(command -v dotnet)"
+ldd_output=$(find "$(dirname "${INSTALL_DIR}")" -type f,l \( -name 'dotnet' -o -name '*.so*' \) -exec ldd '{}' +)
+if grep 'not found' <<<"${ldd_output}" | sort --unique; then
+	echo "The above dynamically linked libraries were not found!"
+	exit 1
+else
+	echo "All dynamically linked libraries were found."
+fi

--- a/spec/fixtures/basic_web_8.0/bin/test-runtime.sh
+++ b/spec/fixtures/basic_web_8.0/bin/test-runtime.sh
@@ -2,10 +2,17 @@
 
 set -euo pipefail
 
-# Check that all dynamically linked libraries exist in the run image
+# Check that all required dynamically linked libraries can be found in the run image.
+
+# Capture `ldd` output for `dotnet` executables and `*.so*` shared libraries in the `dotnet` install directory.
 INSTALL_DIR="$(command -v dotnet)"
 ldd_output=$(find "$(dirname "${INSTALL_DIR}")" -type f,l \( -name 'dotnet' -o -name '*.so*' \) -exec ldd '{}' +)
-if grep 'not found' <<<"${ldd_output}" | sort --unique; then
+
+# Check for missing libraries.
+# An exception is made for `liblttng-ust.so.0`, which is filtered out as it is considered
+# non-critical, and expected to be missing in some environments.
+# For more info, see: https://github.com/heroku/base-images/pull/346#issuecomment-2715075259
+if grep 'not found' <<<"${ldd_output}" | grep -v 'liblttng-ust.so.0' | sort --unique; then
 	echo "The above dynamically linked libraries were not found!"
 	exit 1
 else

--- a/spec/hatchet/buildpack_spec.rb
+++ b/spec/hatchet/buildpack_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe 'Buildpack execution' do
         REGEX
 
         expect(app.run('bin/test-runtime.sh')).to match('All dynamically linked libraries were found.')
+        expect($CHILD_STATUS.exitstatus).to be_zero
+        expect($CHILD_STATUS).to be_success
       end
     end
   end

--- a/spec/hatchet/buildpack_spec.rb
+++ b/spec/hatchet/buildpack_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe 'Buildpack execution' do
           remote:        Procfile declares types     -> \\(none\\)
           remote:        Default types for buildpack -> web
         REGEX
+
+        expect(app.run('bin/test-runtime.sh')).to match('All dynamically linked libraries were found.')
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ ENV['HATCHET_DEFAULT_STACK'] ||= 'heroku-24'
 require 'rspec/core'
 require 'rspec/retry'
 require 'hatchet'
+require 'English'
 
 FIXTURE_DIR = Pathname.new(__FILE__).parent.join('fixtures')
 


### PR DESCRIPTION
This PR:

* Adds a check verifying that required dynamically linked libraries are available in the run image.

Also see https://github.com/heroku/base-images/pull/346#issuecomment-2715075259.