### PR TITLE
Purge layers based on metadata

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -130,8 +130,8 @@ run_build() {
 	"${CNB_BUILDPACK_DIR}/bin/build" "${CNB_BUILD_DIR}/layers" "${CNB_BUILD_DIR}/platform" "${CNB_BUILD_DIR}/buildpack_plan.toml" |& format_cnb_output
 }
 
-# Remove build layers to reduce slug size
-remove_build_layers() {
+# Purge non-launch layers to reduce slug size
+remove_non_launch_layers() {
 	for layer_toml in "${CNB_BUILD_DIR}/layers/"*.toml; do
 		case "$(basename "${layer_toml}")" in
 			launch.toml | build.toml | store.toml)
@@ -165,5 +165,5 @@ process_env_files() {
 initialize_environment
 download_and_extract_cnb
 run_build
-remove_build_layers
+remove_non_launch_layers
 process_env_files

--- a/bin/compile
+++ b/bin/compile
@@ -132,8 +132,17 @@ run_build() {
 
 # Remove build layers to reduce slug size
 remove_build_layers() {
-	for item in "sdk" "nuget-cache"; do
-		rm -rf "${CNB_BUILD_DIR}/layers/${item}" "${CNB_BUILD_DIR}/layers/${item}.toml"
+	for layer_toml in "${CNB_BUILD_DIR}/layers/"*.toml; do
+		case "$(basename "${layer_toml}")" in
+			launch.toml | build.toml | store.toml)
+				continue
+				;;
+			*)
+				if ! grep -q '^launch = true' "${layer_toml}"; then
+					rm -rf "${layer_toml%.toml}" "${layer_toml}"
+				fi
+				;;
+		esac
 	done
 }
 


### PR DESCRIPTION
Inspect <layer>.toml metadata files to detect launch layers to preserve. This doesn't affect the current functionality (as neither the `nuget-cache` or `sdk` layers are launch layers).