### PR TITLE
Refactor launch process parsing

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -10,26 +10,15 @@ launch_toml_file="${CNB_BUILD_DIR}/layers/launch.toml"
 
 # Check if launch.toml exists and output default_process_types in YAML
 if [[ -f "${launch_toml_file}" ]]; then
+	BUILDPACK_DIR=$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)
+	source "${BUILDPACK_DIR:?}/lib/cnb_process_utils.sh"
+
+	declare -A launch_processes
+	parse_launch_processes launch_processes "${launch_toml_file}"
+
 	echo "---"
 	echo "default_process_types:"
-
-	type=""
-	command=""
-
-	while IFS= read -r line; do
-		# Extract the type from lines like `type = "web"`
-		if [[ ${line} =~ ^type[[:space:]]*=[[:space:]]*\"([^\"]+)\" ]]; then
-			type="${BASH_REMATCH[1]}"
-		fi
-
-		# Extract the command from lines like `command = ["bash", "-c", "run_command"]`
-		if [[ ${line} =~ ^command[[:space:]]*=[[:space:]]*\[\"bash\",[[:space:]]*\"-c\",[[:space:]]*\"(.*)\"[[:space:]]*\] ]]; then
-			command="${BASH_REMATCH[1]}"
-
-			# Output each process type in YAML format
-			echo "  ${type}: \"${command}\""
-			type=""
-			command=""
-		fi
-	done <"${launch_toml_file}"
+	for type in "${!launch_processes[@]}"; do
+		echo "  ${type}: \"${launch_processes[${type}]}\""
+	done
 fi

--- a/lib/cnb_process_utils.sh
+++ b/lib/cnb_process_utils.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+parse_launch_processes() {
+	local -n _processes=$1
+	local launch_toml_file="${2}"
+
+	local type=""
+	local command=""
+
+	while IFS= read -r line; do
+		# Extract the type from lines like `type = "web"`
+		if [[ ${line} =~ ^type[[:space:]]*=[[:space:]]*\"([^\"]+)\" ]]; then
+			type="${BASH_REMATCH[1]}"
+		fi
+
+		# Extract the command from lines like `command = ["bash", "-c", "run_command"]`
+		if [[ ${line} =~ ^command[[:space:]]*=[[:space:]]*\[\"bash\",[[:space:]]*\"-c\",[[:space:]]*\"(.*)\"[[:space:]]*\] ]]; then
+			command="${BASH_REMATCH[1]}"
+			_processes["${type}"]="${command}"
+			type=""
+			command=""
+		fi
+	done <"${launch_toml_file}"
+}

--- a/lib/cnb_process_utils.sh
+++ b/lib/cnb_process_utils.sh
@@ -8,6 +8,7 @@ parse_launch_processes() {
 
 	local type=""
 	local command=""
+	local line
 
 	while IFS= read -r line; do
 		# Extract the type from lines like `type = "web"`


### PR DESCRIPTION
The CNB will soon support test execution environments, where we'll need to parse launch processes without the YAML-formatted output from`bin/release` (that will run in `bin/test`).

This PR extracts the shareable `launch.toml` process parsing logic to help support that use case.