### PR TITLE
Support Heroku CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support for Heroku CI. ([#58](https://github.com/heroku/heroku-buildpack-dotnet/pull/58))
 
 ## [v10] - 2025-03-11
 

--- a/bin/test
+++ b/bin/test
@@ -22,8 +22,16 @@ if [[ -n "${launch_processes[${test_process_type}]:-}" ]]; then
 	cd "${BUILD_DIR}"
 	eval "${launch_processes[${test_process_type}]}" |& output::indent
 else
-	# When the CNB supports the test execution environment, a `test` process will
-	# always be added during compilation, so users should never see this.
-	echo "Error: No '${test_process_type}' process found in launch.toml." >&2
+	# A `test` process type should always be added during compilation, so
+	# (official GitHub/buildpack registry releases) should never produce
+	# this error. We may also want to add report/track errors like these.
+	output::error <<-EOF
+		Error: No '${test_process_type}' process found in launch.toml.
+
+		This error is most likely caused by an internal buildpack bug.
+
+		If you see this error, please file an issue here:
+		https://github.com/heroku/heroku-buildpack-dotnet/issues/new
+	EOF
 	exit 1
 fi

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Usage: bin/test <build-dir> <env-dir>
+# See: https://devcenter.heroku.com/articles/testpack-api#bin-test
+
+set -euo pipefail
+
+BUILD_DIR="${1}"
+CNB_BUILD_DIR="${BUILD_DIR}/.heroku/cnb/dotnet"
+
+BUILDPACK_DIR=$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)
+
+source "${BUILDPACK_DIR:?}/lib/cnb_process_utils.sh"
+source "${BUILDPACK_DIR:?}/lib/output.sh"
+
+declare -A launch_processes
+parse_launch_processes launch_processes "${CNB_BUILD_DIR}/layers/launch.toml"
+
+test_process_type="test"
+if [[ -n "${launch_processes[${test_process_type}]:-}" ]]; then
+	echo "Running ${test_process_type} command: \`${launch_processes[${test_process_type}]}\`" | output::indent
+
+	cd "${BUILD_DIR}"
+	eval "${launch_processes[${test_process_type}]}" |& output::indent
+else
+	# When the CNB supports the test execution environment, a `test` process will
+	# always be added during compilation, so users should never see this.
+	echo "Error: No '${test_process_type}' process found in launch.toml." >&2
+	exit 1
+fi

--- a/bin/test-compile
+++ b/bin/test-compile
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Usage: bin/test-compile <build-dir> <cache-dir> <env-dir>
+# See: https://devcenter.heroku.com/articles/testpack-api#bin-test-compile
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+BUILDPACK_DIR=$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)
+
+CNB_EXEC_ENV="test" "${BUILDPACK_DIR}/bin/compile" "${1}" "${2}" "${3}"

--- a/lib/output.sh
+++ b/lib/output.sh
@@ -7,6 +7,16 @@ set -euo pipefail
 ANSI_RED='\033[1;31m'
 ANSI_RESET='\033[0m'
 
+# Indent passed stdout. Typically used to indent command output within a step.
+#
+# Usage:
+# ```
+# dotnet test ... | output::indent
+# ```
+function output::indent() {
+	sed --unbuffered "s/^/       /"
+}
+
 # Output a styled multi-line error message to stderr.
 #
 # Usage:

--- a/spec/fixtures/netslnwithtests/global.json
+++ b/spec/fixtures/netslnwithtests/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+        "version": "9.0.201",
+        "rollForward": "disable"
+    }
+}

--- a/spec/fixtures/netslnwithtests/netslnwithtests.sln
+++ b/spec/fixtures/netslnwithtests/netslnwithtests.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xunittests", "xunittests\xunittests.csproj", "{190E587B-9C4F-4223-A957-781703C67D7E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{190E587B-9C4F-4223-A957-781703C67D7E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{190E587B-9C4F-4223-A957-781703C67D7E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{190E587B-9C4F-4223-A957-781703C67D7E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{190E587B-9C4F-4223-A957-781703C67D7E}.Debug|x64.Build.0 = Debug|Any CPU
+		{190E587B-9C4F-4223-A957-781703C67D7E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{190E587B-9C4F-4223-A957-781703C67D7E}.Debug|x86.Build.0 = Debug|Any CPU
+		{190E587B-9C4F-4223-A957-781703C67D7E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{190E587B-9C4F-4223-A957-781703C67D7E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{190E587B-9C4F-4223-A957-781703C67D7E}.Release|x64.ActiveCfg = Release|Any CPU
+		{190E587B-9C4F-4223-A957-781703C67D7E}.Release|x64.Build.0 = Release|Any CPU
+		{190E587B-9C4F-4223-A957-781703C67D7E}.Release|x86.ActiveCfg = Release|Any CPU
+		{190E587B-9C4F-4223-A957-781703C67D7E}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/spec/fixtures/netslnwithtests/xunittests/UnitTest1.cs
+++ b/spec/fixtures/netslnwithtests/xunittests/UnitTest1.cs
@@ -1,0 +1,9 @@
+﻿namespace xunittests;
+
+public class UnitTest1
+{
+    [Fact]
+    public void Test1()
+    {
+    }
+}

--- a/spec/fixtures/netslnwithtests/xunittests/xunittests.csproj
+++ b/spec/fixtures/netslnwithtests/xunittests/xunittests.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+
+RSpec.describe 'Heroku CI' do
+  context 'when using solution with a test project' do
+    let(:app) { Hatchet::Runner.new('spec/fixtures/netslnwithtests') }
+
+    it 'installs SDK and runs tests' do
+      app.run_ci do |test_run|
+        expect(clean_output(test_run.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
+          -----> .NET app detected
+          -----> SDK version detection
+                 Detected .NET file to publish: `/app/netslnwithtests.sln`
+                 Detecting version requirement from root global.json file
+                 Detected version requirement: `=9.0.201`
+                 Resolved .NET SDK version `9.0.201` \\(linux-amd64\\)
+          -----> SDK installation
+                 Downloading SDK from https://download.visualstudio.microsoft.com/download/pr/82a7fc96-b53b-4af4-ac3a-ef0a6c9325d5/84e522c31482538cddf696d03c5b20af/dotnet-sdk-9.0.201-linux-x64.tar.gz .*
+                 Verifying SDK checksum
+                 Installing SDK
+          -----> Done .*
+          -----> No test-setup command provided. Skipping.
+          -----> Running .NET buildpack tests...
+                 Running test command: `dotnet test /app/netslnwithtests.sln`
+                   Determining projects to restore...
+                   Restored /app/xunittests/xunittests.csproj .*
+                   xunittests -> /app/xunittests/bin/Debug/net9.0/xunittests.dll
+                 Test run for /app/xunittests/bin/Debug/net9.0/xunittests.dll \\(.NETCoreApp,Version=v9.0\\)
+                 VSTest version 17.13.0 \\(x64\\)
+                 
+                 Starting test execution, please wait...
+                 A total of 1 test files matched the specified pattern.
+                 
+                 Passed!  - Failed:     0, Passed:     1, Skipped:     0, Total:     1, Duration: .* - xunittests.dll \\(net9.0\\)
+          -----> .NET buildpack tests completed successfully
+        REGEX
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR implements the [Testpack API](https://devcenter.heroku.com/articles/testpack-api) to provide full support for [Heroku CI](https://devcenter.heroku.com/articles/heroku-ci).

The buildpack will install the .NET SDK, configure the test environment, and test projects/solutions using [`dotnet test`](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test) ensuring compatibility with most .NET testing frameworks, tools and platforms.

Note that while this buildpack is in beta, the buildpack URL has to be specified in [an app.json file](https://devcenter.heroku.com/articles/heroku-ci#configure-your-test-environment):

```
{
  "buildpacks": [
    {"url": "https://github.com/heroku/heroku-buildpack-dotnet"}
  ]
}
```

Also see https://github.com/heroku/buildpacks-dotnet/pull/222 for more details on the underlying implementation.