### PR TITLE
Pin SHA of third-party GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,8 @@ updates:
       - "dependencies"
       - "github actions"
       - "skip changelog"
+    groups:
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/cnb.yml
+++ b/.github/workflows/cnb.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Create Pull Request
         id: create_pr
-        uses: peter-evans/create-pull-request@v7.0.7
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           token: ${{ steps.generate-token.outputs.token }}
           reviewers: runesoerensen


### PR DESCRIPTION
The full-version Git tags used by Actions are mutable (as seen in recent events in the wider GitHub Actions community), so pinning third-party Actions to a SHA is recommended:
https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

The version tag has been added after the pin as a comment (as a readability aid) in a format that Dependabot will keep up to date: https://github.com/dependabot/dependabot-core/issues/4691

I've also enabled Dependabot grouping for GitHub Actions updates to reduce PR noise.

GUS-W-18051077.