### PR TITLE
Support arbitrary launch process commands

### DIFF
--- a/lib/cnb_process_utils.sh
+++ b/lib/cnb_process_utils.sh
@@ -28,8 +28,10 @@ parse_launch_processes() {
 				local arg="${BASH_REMATCH[1]}"
 				command+=("${arg}")
 
-				# Quote argument if it contains spaces
-				if [[ "${arg}" =~ [[:space:]] ]]; then
+				# Quote arg if it differs from it's own `printf '%q'` formatting. This
+				# is a hack to check for special characters that'd need escaping (while
+				# preferring to quote the arg for readability) without using regex, sed etc.
+				if [[ "$(printf '%q' "${arg}")" != "${arg}" ]]; then
 					quoted_command+=("\"${arg}\"")
 				else
 					quoted_command+=("${arg}")

--- a/lib/cnb_process_utils.sh
+++ b/lib/cnb_process_utils.sh
@@ -15,7 +15,8 @@ parse_launch_processes() {
 			type="${BASH_REMATCH[1]}"
 		fi
 
-		# Extract command array from lines like `command = ["bash", "-c", "run_command"]`, or `command = ["dotnet", "test", "foo.sln"]`
+		# Extract command array from lines like `command = ["bash", "-c", "run_command"]`,
+		# `command = ["dotnet", "test", "foo.csproj", "--verbosity", "normal"]`.
 		if [[ ${line} =~ ^command[[:space:]]*=[[:space:]]*\[(.*)\] ]]; then
 			local command=()
 			local raw_command="${BASH_REMATCH[1]}"


### PR DESCRIPTION
This PR changes how the launch.toml is parsed, to allow arbitrary process `command` lists (while retaining the current special handling for bash processes):

* The behavior for launch.toml command definitions like `["bash", "-c", "cd foobar/; ./foobar"]` is unchanged. The third argument is used to define the process used by this buildpack (e.g. when detecting default process types in `bin/release`).
* Commands that do not rely on bash wrapping are now supported by the `launch.toml` parser. Every argument is checked for special characters, and double-quoted as needed.
* This prepares the buildpack to support these changes: https://github.com/heroku/buildpacks-dotnet/pull/240.

Also see these related discussions:
* https://github.com/heroku/buildpacks-dotnet/pull/240#discussion_r2004288060
* https://github.com/heroku/buildpacks-dotnet/pull/240#discussion_r2003112004