### PR TITLE
Unquote default process type commands

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -19,6 +19,6 @@ if [[ -f "${launch_toml_file}" ]]; then
 	echo "---"
 	echo "default_process_types:"
 	for type in "${!launch_processes[@]}"; do
-		echo "  ${type}: \"${launch_processes[${type}]}\""
+		echo "  ${type}: ${launch_processes[${type}]}"
 	done
 fi


### PR DESCRIPTION
This PR simply removes the quotes around process commands from the output produced by `bin/release`. This is inconsequential for all currently supported uses of the buildpack.

However, the recently adopted [CNB changes to support paths with spaces](https://github.com/heroku/heroku-buildpack-dotnet/pull/68) won't work as expected in the following scenario:

* The `CNB_EXEC_ENV` config var is set to `test`.
* The solution/project filename includes spaces/special characters.

Which results in `bin/release` output like this:

```
---
default_process_types:
  test: "dotnet test "solution with spaces.sln""
```

This is very much an unsupported use case currently, as `launch.toml` processes used by `bin/release` never contains double quotes (when targeting the `production` execution environment), and the argument quoting introduced by https://github.com/heroku/heroku-buildpack-dotnet/pull/67 only affects `launch.toml` parsing used in `bin/test`.

It's of course still worth fixing as the command quoting in `bin/release` is unnecessary / not required by neither the `Procfile` nor the Buildpack API specs. It's also quite likely that the CNB will produce `launch.toml` processes differently in the future, e.g. to support `Development` execution environments.