### PR TITLE
Improve CNB download error output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Improved the error messages shown if there is a networking or server related error downloading buildpack dependencies. ([#91](https://github.com/heroku/heroku-buildpack-dotnet/pull/91))
 
 ## [v21] - 2025-06-12
 

--- a/bin/compile
+++ b/bin/compile
@@ -49,10 +49,16 @@ download_and_extract_cnb() {
 	# Download the CNB, modifying file paths to remove leading '/' during extraction
 	if ! curl --silent --show-error --location --fail --retry 3 --retry-connrefused --connect-timeout 10 "${buildpack_url}" | tar --transform 's|^/||' --extract --directory "${temp_dir}"; then
 		output::error <<-EOF
-			Error: Failed to download/extract buildpack from ${buildpack_url}.
+			Error: Failed to download/extract buildpack from GitHub:
+			${buildpack_url}
 
-			In some cases, this happens due to an unstable network connection.
-			Please try again and to see if the error resolves itself.
+			In some cases, this happens due to an unstable network,
+			or GitHub's API/CDN.
+
+			Please try again to see if the error resolves itself.
+
+			If that doesn't help, check the status of GitHub here:
+			https://www.githubstatus.com
 		EOF
 		exit 1
 	fi


### PR DESCRIPTION
Improved the error messages shown if there is a networking or server related error downloading buildpack dependencies. Closes #90

GUS-W-18834865