### PR TITLE
Escape single quote string values for YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `bin/report` output containing single quotes is now properly escaped. ([#101]https://github.com/heroku/heroku-buildpack-dotnet/pull/101)
 
 ## [v24] - 2025-07-15
 

--- a/lib/libcnb_telemetry_build_report.jq
+++ b/lib/libcnb_telemetry_build_report.jq
@@ -54,7 +54,7 @@ def process_span_by_type($summary):
 def format_report:
   to_entries
   | map(select(.value != null))
-  | map("\(.key): \(.value | if type == "string" then "'\(.)'" else tostring end)")
+  | map("\(.key): \(.value | if type == "string" then "'\(. | gsub("'"; "''"))'" else tostring end)")
   | join("\n");
 
 # Extract all spans from all JSON objects in the slurped array


### PR DESCRIPTION
The `lib/libcnb_telemetry_build_report.jq` function produced invalid YAML when string values contained a single quote.

This change uses `jq`'s `gsub` function to replace each `'` with `''`, ensuring the output is always valid YAML.

GUS-W-19063122