### PR TITLE
Display detection failure error message in build logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Detection failure error messages are now correctly displayed in build logs. ([#115](https://github.com/heroku/heroku-buildpack-dotnet/pull/115))
 
 ## [v29] - 2025-08-28
 

--- a/bin/detect
+++ b/bin/detect
@@ -6,11 +6,16 @@ set -euo pipefail
 
 BUILD_DIR="${1}"
 
+# The absolute path to the root of the buildpack.
+BUILDPACK_DIR=$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)
+
+source "${BUILDPACK_DIR}/lib/output.sh"
+
 # Detect .NET project or solution files
 if find "${BUILD_DIR}" -maxdepth 1 -name "*.sln" -o -name "*.csproj" -o -name "*.fsproj" -o -name "*.vbproj" | grep -q .; then
 	echo ".NET"
 	exit 0
 else
-	echo "Error: No .NET project or solution files detected" >&2
+	output::error <<< "Error: No .NET project or solution files detected"
 	exit 1
 fi

--- a/bin/detect
+++ b/bin/detect
@@ -16,6 +16,6 @@ if find "${BUILD_DIR}" -maxdepth 1 -name "*.sln" -o -name "*.csproj" -o -name "*
 	echo ".NET"
 	exit 0
 else
-	output::error <<< "Error: No .NET project or solution files detected"
+	output::error <<< "Error: No .NET solution or project files (such as `foo.sln` or `foo.csproj`) found."
 	exit 1
 fi

--- a/bin/detect
+++ b/bin/detect
@@ -11,6 +11,6 @@ if find "${BUILD_DIR}" -maxdepth 1 -name "*.sln" -o -name "*.csproj" -o -name "*
 	echo ".NET"
 	exit 0
 else
-	echo "Error: No .NET project or solution files detected"
+	echo "Error: No .NET project or solution files detected" >&2
 	exit 1
 fi

--- a/bin/detect
+++ b/bin/detect
@@ -17,5 +17,5 @@ if find "${BUILD_DIR}" -maxdepth 1 -name "*.sln" -o -name "*.csproj" -o -name "*
 	exit 0
 fi
 
-output::error <<< 'Error: No .NET solution or project files (such as `foo.sln` or `foo.csproj`) found.'
+output::error <<<"Error: No .NET solution or project files (such as \`foo.sln\` or \`foo.csproj\`) found."
 exit 1

--- a/bin/detect
+++ b/bin/detect
@@ -15,7 +15,7 @@ source "${BUILDPACK_DIR}/lib/output.sh"
 if find "${BUILD_DIR}" -maxdepth 1 -name "*.sln" -o -name "*.csproj" -o -name "*.fsproj" -o -name "*.vbproj" | grep -q .; then
 	echo ".NET"
 	exit 0
-else
-	output::error <<< 'Error: No .NET solution or project files (such as `foo.sln` or `foo.csproj`) found.'
-	exit 1
 fi
+
+output::error <<< 'Error: No .NET solution or project files (such as `foo.sln` or `foo.csproj`) found.'
+exit 1

--- a/bin/detect
+++ b/bin/detect
@@ -19,5 +19,8 @@ fi
 
 output::error <<EOF
 Error: No .NET solution or project files (such as \`foo.sln\` or \`foo.csproj\`) found.
+
+For more information, see:
+https://devcenter.heroku.com/articles/dotnet-behavior-in-heroku#auto-detection
 EOF
 exit 1

--- a/bin/detect
+++ b/bin/detect
@@ -16,6 +16,6 @@ if find "${BUILD_DIR}" -maxdepth 1 -name "*.sln" -o -name "*.csproj" -o -name "*
 	echo ".NET"
 	exit 0
 else
-	output::error <<< "Error: No .NET solution or project files (such as `foo.sln` or `foo.csproj`) found."
+	output::error <<< 'Error: No .NET solution or project files (such as `foo.sln` or `foo.csproj`) found.'
 	exit 1
 fi

--- a/bin/detect
+++ b/bin/detect
@@ -17,5 +17,7 @@ if find "${BUILD_DIR}" -maxdepth 1 -name "*.sln" -o -name "*.csproj" -o -name "*
 	exit 0
 fi
 
-output::error <<<"Error: No .NET solution or project files (such as \`foo.sln\` or \`foo.csproj\`) found."
+output::error <<EOF
+Error: No .NET solution or project files (such as \`foo.sln\` or \`foo.csproj\`) found.
+EOF
 exit 1

--- a/spec/hatchet/detect_spec.rb
+++ b/spec/hatchet/detect_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Buildpack detection' do
   # This spec only tests cases where detection fails, since the success cases
   # are already tested in the specs for general buildpack functionality.
 
-  context 'when there are no recognised .NET files' do
+  context 'when there are no recognized .NET files' do
     let(:app) { Hatchet::Runner.new('spec/fixtures/no_dotnet_files', allow_failure: true) }
 
     it 'fails detection' do

--- a/spec/hatchet/detect_spec.rb
+++ b/spec/hatchet/detect_spec.rb
@@ -15,6 +15,9 @@ RSpec.describe 'Buildpack detection' do
           remote: -----> App not compatible with buildpack: #{DEFAULT_BUILDPACK_URL}
           remote:        
           remote:  !     Error: No .NET solution or project files (such as `foo.sln` or `foo.csproj`) found.
+          remote:  !     
+          remote:  !     For more information, see:
+          remote:  !     https://devcenter.heroku.com/articles/dotnet-behavior-in-heroku#auto-detection
           remote: 
           remote: 
           remote:        More info: https://devcenter.heroku.com/articles/buildpacks#detection-failure

--- a/spec/hatchet/detect_spec.rb
+++ b/spec/hatchet/detect_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+
+RSpec.describe 'Buildpack detection' do
+  # This spec only tests cases where detection fails, since the success cases
+  # are already tested in the specs for general buildpack functionality.
+
+  context 'when there are no recognised .NET files' do
+    let(:app) { Hatchet::Runner.new('spec/fixtures/no_dotnet_files', allow_failure: true) }
+
+    it 'fails detection' do
+      app.deploy do |app|
+        expect(clean_output(app.output)).to include(<<~OUTPUT)
+          remote: -----> App not compatible with buildpack: #{DEFAULT_BUILDPACK_URL}
+          remote:        Error: No .NET project or solution files detected
+        OUTPUT
+      end
+    end
+  end
+end

--- a/spec/hatchet/detect_spec.rb
+++ b/spec/hatchet/detect_spec.rb
@@ -13,7 +13,11 @@ RSpec.describe 'Buildpack detection' do
       app.deploy do |app|
         expect(clean_output(app.output)).to include(<<~OUTPUT)
           remote: -----> App not compatible with buildpack: #{DEFAULT_BUILDPACK_URL}
-          remote:        Error: No .NET project or solution files detected
+          remote:        
+          remote:  !     Error: No .NET project or solution files detected
+          remote: 
+          remote: 
+          remote:        More info: https://devcenter.heroku.com/articles/buildpacks#detection-failure
         OUTPUT
       end
     end

--- a/spec/hatchet/detect_spec.rb
+++ b/spec/hatchet/detect_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Buildpack detection' do
         expect(clean_output(app.output)).to include(<<~OUTPUT)
           remote: -----> App not compatible with buildpack: #{DEFAULT_BUILDPACK_URL}
           remote:        
-          remote:  !     Error: No .NET project or solution files detected
+          remote:  !     Error: No .NET solution or project files (such as `foo.sln` or `foo.csproj`) found.
           remote: 
           remote: 
           remote:        More info: https://devcenter.heroku.com/articles/buildpacks#detection-failure


### PR DESCRIPTION
This PR addresses an issue where the detection failure error message wasn't displayed in build logs because it was incorrectly written to `stdout`.

This change redirects the error output to `stderr` so that users receive helpful feedback when the buildpack fails to detect their app.

It also:
* Adds a Hatchet integration test to verify the detection failure output.
* Updates the error message to align it with the .NET CNB's `bin/detect` output (preparing it for upcoming changes to the buildpack detection logic).
* Includes a link to relevant Dev Center content in the error message.

GUS-W-19569682