### PR TITLE
Migrate to Rubocop plugin syntax

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-rspec
 
 AllCops:


### PR DESCRIPTION
Fixes this Rubocop warning:

```
% bundle exec rubocop
rubocop-rspec extension supports plugin, specify `plugins: rubocop-rspec` instead of `require: rubocop-rspec` in /home/runner/work/heroku-buildpack-dotnet/heroku-buildpack-dotnet/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```

GUS-W-19569773