### PR TITLE
Delegate Ruby whitespace handling to RuboCop

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,9 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.rb]
+trim_trailing_whitespace = false
+
 [*.sh]
 binary_next_line = true
 # We sadly have to use tabs in shell scripts otherwise we can't indent here documents:


### PR DESCRIPTION
This PR delegates trailing whitespace handling for Ruby files from `.editorconfig` to RuboCop.

The `trim_trailing_whitespace = true` setting in `.editorconfig` conflicted with RSpec tests that require trailing whitespace in heredoc assertions. While our CI lint workflow ultimately enforce the correct formatting, this conflict creates unnecessary friction during local development.

This change establishes RuboCop as the single source of truth for Ruby formatting, relying on our existing `AllowInHeredoc: true` setting to correctly handle these test cases while still enforcing whitespace rules everywhere else. This improves developer ergonomics by aligning the editor's behavior with our CI standards.

To get auto-formatting on save with these rules, developers using VS Code can install the [official RuboCop extension](https://marketplace.visualstudio.com/items?itemName=rubocop.vscode-rubocop).

GUS-W-19569867