### PR TITLE
Update Dev Center link in `bin/detect` failure message

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -37,6 +37,6 @@ If your app already has a solution or project file, check that it:
 Otherwise, add a .NET solution or project file to your app's root directory.
 
 For more information, see:
-https://devcenter.heroku.com/articles/dotnet-behavior-in-heroku#auto-detection
+https://devcenter.heroku.com/articles/dotnet-behavior-in-heroku#auto-detection-and-build-behavior
 EOF
 exit 1

--- a/spec/hatchet/detect_spec.rb
+++ b/spec/hatchet/detect_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Buildpack detection' do
           remote:  !     Otherwise, add a .NET solution or project file to your app's root directory.
           remote:  !     
           remote:  !     For more information, see:
-          remote:  !     https://devcenter.heroku.com/articles/dotnet-behavior-in-heroku#auto-detection
+          remote:  !     https://devcenter.heroku.com/articles/dotnet-behavior-in-heroku#auto-detection-and-build-behavior
           remote: 
           remote: 
           remote:        More info: https://devcenter.heroku.com/articles/buildpacks#detection-failure


### PR DESCRIPTION
Update Dev Center link to reflect a recent change to the Dev Center documentation.

GUS-W-19668250