### PR TITLE
Fix build log output assertion

### DIFF
--- a/spec/hatchet/buildpack_spec.rb
+++ b/spec/hatchet/buildpack_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe 'Buildpack execution' do
     it 'successfully compiles' do
       app.deploy do |app|
         expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
-          remote: -----> Using buildpack: #{DEFAULT_BUILDPACK_URL}
           remote: -----> .NET app detected
           remote: -----> SDK version detection
           remote:        Detected .NET project: `/tmp/build_.*/foo.csproj`


### PR DESCRIPTION
The build system now prints a warning when the buildpack URL includes the branch name.

GUS-W-21974681