### PR TITLE
Further reduce team review request noise from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,3 +11,4 @@
 CHANGELOG.md @runesoerensen
 Gemfile.lock @runesoerensen
 /.github/workflows/ @runesoerensen
+/bin/compile @runesoerensen


### PR DESCRIPTION
Similar to #95 this adds more files to the CODEOWNERS list of files updated by automation - specifically `bin/compile` which gets updated by PRs like #201.

GUS-W-22817257.