### PR TITLE
Add OIDC-based release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  # Auto-trigger when the "Prepare release" PR (created by the
+  # _classic-buildpack-prepare-release.yml workflow) is merged.
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+  workflow_dispatch:
+    inputs:
+      qa:
+        description: "QA mode (staging registry, -qa tag suffix, draft releases)"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    # On `pull_request`, only run for the merged auto-generated
+    # "Prepare release" PR (branch name set by
+    # _classic-buildpack-prepare-release.yml). Manual dispatches always run.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       github.event.pull_request.head.ref == 'prepare-release' &&
+       github.event.pull_request.user.login == 'heroku-linguist[bot]')
+    uses: heroku/languages-github-actions/.github/workflows/_classic-buildpack-publish.yml@latest
+    with:
+      buildpack_id: "heroku/dotnet"
+      # `inputs.qa` is unset on `pull_request`, so coerce to false — auto-triggered
+      # publishes always go to production. Manual dispatches pass the input through.
+      qa: ${{ inputs.qa || false }}


### PR DESCRIPTION
Calls the shared `_classic-buildpack-publish.yml` workflow from `heroku/languages-github-actions` to publish the `heroku/dotnet` buildpack to the registry via OIDC.

Auto-triggers when the Linguist-authored "Prepare release" PR is merged to `main` (guarded on event, branch, repo, and PR author). Also supports manual `workflow_dispatch` with a QA toggle for staging publishes.

Mirrors the pattern established in heroku/heroku-buildpack-nodejs#1653.

W-22295409 is the reference implementation; this is the dotnet caller workflow for the OIDC-Based Classic Buildpack Publishing epic.

W-22295391