### PR TITLE
Fix ruff lint issues (EXE001, I001, SIM115)

### DIFF
--- a/lib/parse_launch_toml.py
+++ b/lib/parse_launch_toml.py
@@ -7,8 +7,8 @@ Supports two output formats:
 - --process <type>: Command for a single process type (e.g., as used in `bin/test`)
 """
 
-import sys
 import shlex
+import sys
 from pathlib import Path
 
 # `tomli`/`tomllib` compatibility layer: Use `tomllib` if available in the

--- a/tests/test_parse_launch_toml.py
+++ b/tests/test_parse_launch_toml.py
@@ -51,12 +51,11 @@ class TestParseLaunchToml(unittest.TestCase):
 
     def setUp(self):
         """Set up a temporary TOML file for each test."""
-        self.temp_toml_file = tempfile.NamedTemporaryFile(
+        with tempfile.NamedTemporaryFile(
             mode="w", delete=False, suffix=".toml"
-        )
-        self.temp_toml_file.write(TEST_TOML_CONTENT)
-        self.temp_toml_file.close()
-        self.toml_path = self.temp_toml_file.name
+        ) as temp_toml_file:
+            temp_toml_file.write(TEST_TOML_CONTENT)
+        self.toml_path = temp_toml_file.name
 
     def tearDown(self):
         """Clean up the temporary TOML file after each test."""


### PR DESCRIPTION
## Summary
- `lib/parse_launch_toml.py`: made executable (EXE001, matches its shebang) and sorted imports (I001)
- `tests/test_parse_launch_toml.py`: use a context manager for the temp file in `setUp` instead of manual open/close (SIM115)

Fixes the ruff failures from https://github.com/heroku/heroku-buildpack-dotnet/actions/runs/30716164902/job/91411957465?pr=223#step:9:11

GUS-W-23754425